### PR TITLE
guvectorize the original python functions instead of the jitted ones

### DIFF
--- a/homog/quat.py
+++ b/homog/quat.py
@@ -132,7 +132,7 @@ def numba_rot_to_quat(xform):
 gu_rot_to_quat = guvec([
     (float64[:, :], float64[:]),
     (float32[:, :], float32[:]),
-], '(n,n)->(n)', kernel_rot_to_quat)
+], '(n,n)->(n)', kernel_rot_to_quat.py_func)
 
 
 def quat_to_rot(quat, dtype='f8', shape=(3, 3)):
@@ -186,7 +186,7 @@ def kernel_quat_multiply(q, r, out):
 
 
 gu_quat_multiply = guvec([(float64[:], float64[:], float64[:])],
-                         '(n),(n)->(n)', kernel_quat_multiply)
+                         '(n),(n)->(n)', kernel_quat_multiply.py_func)
 
 
 @jit


### PR DESCRIPTION
Hi Will, this fixes a bug where homog can't be imported successfully. Not sure if this is the optimal way to fix it, but it at least enables homog to be imported again and work correctly. If this looks good to you, it would be great if you could also update it in pypi. Thanks!